### PR TITLE
Updated COC with pre-event concerns and added contact info 

### DIFF
--- a/content/codeofconduct.md
+++ b/content/codeofconduct.md
@@ -32,24 +32,30 @@ Nor'eastR Conference attendants agree to:
 - Alert a member of the organizing team (listed below) if you notice a dangerous situation, someone in distress, or violations of this code of conduct, even if they seem inconsequential.
 - If you are asked to stop harassing behaviour you should stop immediately, even if your behaviour was meant to be friendly or a joke, it was clearly not taken that way and for the comfort of all conference attendees you should stop.
 
-## Sponsors
+### Sponsors
 Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material.
 
-## Requirements for talks
+### Requirements for talks
 Talk slides and presentations fall under the code of conduct. Talk slides should not contain offensive of sexualised material. If this material is impossible to avoid given the topic (for example text mining of material from hate sites) the existence of this material should be noted both in the abstract and at the start of the talk as a trigger warning.
 
-## Need help?
+### Pre-Event Concerns
+
+If you are planning to attend an upcoming event, and have concerns regarding another individual who may be present, please contact a member of the planning committee (see below for contact information). Precautions will be taken to ensure a victim's comfort and safety, including, but not limited to: providing an escort, prepping onsite event staff, keeping victim and harasser from attending the same talks/social events, and providing onsite contact cell phone numbers for immediate contact.  In extreme cases, we may take action to prevent the harasser from attending the conference.
+
+### Need help?
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the Nor'eastR Conference organizing team.
 
-- Richie Cotton
-- Garrett Dancik
-- Jasmine Dumas
-- Marianna Foos
-- Douglas Friedman
-- Jeff Hollister
+- Richie Cotton <richie at datacamp.com>
+- Garrett Dancik <garrett.dancik at gmail.com>
+- Jasmine Dumas <jasmine.dumas at gmail.com>
+- Marianna Foos <marianna.foos at gmail.com>
+- Douglas Friedman <dfriedm4 at its.jnj.com>
+- Jeff Hollister <jeff.w.hollister at gmail.com>
+
+Alternatively, you may go to the registration desk on the day of the conference and a member of the planning committee or a conference volunteer will be there to assist you.
 
 #### General Contact: info@noreastrconf.com
 
 
-Adapted from https://user2018.r-project.org/code_of_conduct/
+Adapted from https://user2018.r-project.org/code_of_conduct/ and https://github.com/RConsortium/RCDI-WG/blob/master/conduct/code-of-conduct.md


### PR DESCRIPTION
All,

Before I merge this wanted to give everyone a chance to look at it.  This includes a new section on pre-event concerns as is suggested in the RConsortium draft COC.  Also, I added email addresses with contact info.  

Take a look at this and we can discuss on the call we have scheduled for Monday.

cc @doug-friedman

(sorry doug, I hadn't added you as a member of the org!  Should have an invite now)
